### PR TITLE
Use DNS-Over-HTTPS (JSON) spec for DNS lookup.

### DIFF
--- a/src/DNS.php
+++ b/src/DNS.php
@@ -13,7 +13,7 @@ class DNS
     {
         $hostname = '_acme-challenge.' . str_replace('*.', '', $domain);
 
-        $records = new DNSOverHTTPS(DNSOverHTTPS::Google);
+        $records = new DNSOverHTTPS(DNSOverHTTPS::DNS_GOOGLE);
         $records = $records->get($hostname, 'TXT');
 
         foreach ($records->Answer as $record) {

--- a/src/DNS.php
+++ b/src/DNS.php
@@ -12,9 +12,12 @@ class DNS
     public function checkChallenge($domain, $requiredDigest)
     {
         $hostname = '_acme-challenge.' . str_replace('*.', '', $domain);
-        $records =  dns_get_record($hostname, DNS_TXT);
-        foreach ($records as $record) {
-            if ($record['host'] == $hostname && $record['type'] == 'TXT' && $record['txt'] == $requiredDigest) {
+
+        $records = new DNSOverHTTPS(DNSOverHTTPS::Google);
+        $records = $records->get($hostname, 'TXT');
+
+        foreach ($records->Answer as $record) {
+            if ($record->host == $hostname && $record->type == 16 && $record->data == $requiredDigest) {
                 return true;
             }
         }

--- a/src/DNS.php
+++ b/src/DNS.php
@@ -17,7 +17,7 @@ class DNS
         $records = $records->get($hostname, 'TXT');
 
         foreach ($records->Answer as $record) {
-            if ($record->host == $hostname && $record->type == 16 && $record->data == $requiredDigest) {
+            if (rtrim($record->name, ".") == $hostname && $record->type == 16 && trim($record->data, '"') == $requiredDigest) {
                 return true;
             }
         }

--- a/src/Helpers/DNSOverHTTPS.php
+++ b/src/Helpers/DNSOverHTTPS.php
@@ -29,10 +29,11 @@ namespace Elphin\LEClient;
 use GuzzleHttp\Client;
 use Psr\Http\Message\ResponseInterface;
 
-class DNSOverHTTPS{
+class DNSOverHTTPS
+{
 
-    const CloudFlare = 'https://cloudflare-dns.com/dns-query';
-    const Google = 'https://dns.google.com/resolve';
+    const DNS_CLOUDFLARE = 'https://cloudflare-dns.com/dns-query';
+    const DNS_GOOGLE = 'https://dns.google.com/resolve';
 
     /**
      * Domain to query
@@ -69,10 +70,11 @@ class DNSOverHTTPS{
     public function __construct(string $baseURI = null)
     {
         //Default to Google, seems like a safe bet...
-        if ($baseURI === null)
+        if ($baseURI === null) {
             $this->baseURI = 'https://dns.google.com/resolve';
-        else
+        } else {
             $this->baseURI = $baseURI;
+        }
 
         $this->client = new Client([
             'base_uri' => $this->baseURI,
@@ -94,8 +96,9 @@ class DNSOverHTTPS{
             ]
         ];
 
-        if(strpos($this->baseURI, 'cloudflare'))
+        if (strpos($this->baseURI, 'cloudflare')) {
             $query['query']['ct'] = 'application/dns-json'; //CloudFlare forces this tag, Google ignores
+        }
 
         $response = $this->client->get(null, $query);
 
@@ -119,5 +122,4 @@ class DNSOverHTTPS{
             throw new \RuntimeException($json->errors[0]->message, $json->errors[0]->code);
         }
     }
-
 }

--- a/src/Helpers/DNSOverHTTPS.php
+++ b/src/Helpers/DNSOverHTTPS.php
@@ -1,27 +1,28 @@
 <?php
 
-/*  DNSOverHTTPS
- *  ------------------------------------------
- *  Author: wutno (#/g/punk - Rizon)
- *  Last update: 4/4/2018 1:48PM -5GMT
+/* DNSOverHTTPS
  *
+ * MIT License
  *
- *  GNU License Agreement
- *  ---------------------
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License version 2 as
- *  published by the Free Software Foundation.
+ * Copyright (c) 2018 wutno (#/g/punk - Rizon)
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
- *  http://www.gnu.org/licenses/gpl-2.0.txt
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 namespace Elphin\LEClient;
@@ -71,7 +72,7 @@ class DNSOverHTTPS
     {
         //Default to Google, seems like a safe bet...
         if ($baseURI === null) {
-            $this->baseURI = 'https://dns.google.com/resolve';
+            $this->baseURI = self::DNS_GOOGLE;
         } else {
             $this->baseURI = $baseURI;
         }

--- a/src/Helpers/DNSOverHTTPS.php
+++ b/src/Helpers/DNSOverHTTPS.php
@@ -1,0 +1,123 @@
+<?php
+
+/*  DNSOverHTTPS
+ *  ------------------------------------------
+ *  Author: wutno (#/g/punk - Rizon)
+ *  Last update: 4/4/2018 1:48PM -5GMT
+ *
+ *
+ *  GNU License Agreement
+ *  ---------------------
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ *  http://www.gnu.org/licenses/gpl-2.0.txt
+ */
+
+namespace Elphin\LEClient;
+
+use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
+
+class DNSOverHTTPS{
+
+    const CloudFlare = 'https://cloudflare-dns.com/dns-query';
+    const Google = 'https://dns.google.com/resolve';
+
+    /**
+     * Domain to query
+     *
+     * @var $name string
+     */
+    public $name;
+
+    /**
+     * Type of query
+     *
+     * @var $type string
+     */
+    public $type;
+
+    /**
+     * What DNS-over-HTTPS service to use
+     *
+     * @var null|string
+     */
+    private $baseURI;
+
+    /**
+     * Guzzle client handler
+     *
+     * @var Client object
+     */
+    private $client;
+
+    /**
+     * DNSOverHTTPS constructor.
+     * @param string|null $baseURI
+     */
+    public function __construct(string $baseURI = null)
+    {
+        //Default to Google, seems like a safe bet...
+        if ($baseURI === null)
+            $this->baseURI = 'https://dns.google.com/resolve';
+        else
+            $this->baseURI = $baseURI;
+
+        $this->client = new Client([
+            'base_uri' => $this->baseURI,
+            'Accept' => 'application/json'
+        ]);
+    }
+
+    /**
+     * @param string $name
+     * @param string $type per experimental spec this can be string OR int, we force string
+     * @return \stdClass
+     */
+    public function get(string $name, string $type) : \stdClass
+    {
+        $query = [
+            'query' => [
+                'name' => $name,
+                'type' => $type
+            ]
+        ];
+
+        if(strpos($this->baseURI, 'cloudflare'))
+            $query['query']['ct'] = 'application/dns-json'; //CloudFlare forces this tag, Google ignores
+
+        $response = $this->client->get(null, $query);
+
+        $this->checkError($response);
+
+        return json_decode($response->getBody());
+    }
+
+    /**
+     * @param ResponseInterface $response
+     */
+    private function checkError(ResponseInterface $response) : void
+    {
+        $json = json_decode($response->getBody());
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \RuntimeException();
+        }
+
+        if (isset($json->errors) && count($json->errors) >= 1) { //not current in spec
+            throw new \RuntimeException($json->errors[0]->message, $json->errors[0]->code);
+        }
+    }
+
+}


### PR DESCRIPTION
I was noticing some intermittent issues with ```dns_get_record()``` where dig would report that the result is indeed present but LEClient would not, as if PHP were caching the results.

Currently the JSON spec has not been agreed upon however both Google and Cloudflare use the same implementation.