### PR TITLE
Ensure the order is still valid

### DIFF
--- a/src/LEOrder.php
+++ b/src/LEOrder.php
@@ -158,7 +158,7 @@ class LEOrder
         //ensure the order is still valid
         if ($get['body']['status'] === 'invalid') {
             //@codeCoverageIgnoreStart
-            $this->log->warning("Order for {$this->basename} has the status 'invalid', unable to authorize. Creating new order.");
+            $this->log->warning("Order for {$this->basename} is 'invalid', unable to authorize. Creating new order.");
             $this->deleteOrderFiles();
             return false;
             //@codeCoverageIgnoreEnd

--- a/src/LEOrder.php
+++ b/src/LEOrder.php
@@ -155,6 +155,15 @@ class LEOrder
             //@codeCoverageIgnoreEnd
         }
 
+        //ensure the order is still valid
+        if ($get['body']['status'] === 'invalid') {
+            //@codeCoverageIgnoreStart
+            $this->log->warning("Order for {$this->basename} has the status 'invalid', unable to authorize. Creating new order.");
+            $this->deleteOrderFiles();
+            return false;
+            //@codeCoverageIgnoreEnd
+        }
+
         //ensure retrieved order matches our domains
         $orderdomains = array_map(function ($ident) {
             return $ident['value'];


### PR DESCRIPTION
When requesting a certificate and the order fails due to invalid authorization, it's impossible to "revive" the order again. This ensures that the existing order will be deleted and a new one be created.

Hopefully this is the right solution, always open for feedback :)