### PR TITLE
LetsEncrypt API now returns a 200 status for HEAD requests for nonce

### DIFF
--- a/src/LEConnector.php
+++ b/src/LEConnector.php
@@ -87,7 +87,7 @@ class LEConnector
     {
         $result = $this->head($this->newNonce);
 
-        if ($result['status'] !== 204) {
+        if ($result['status'] !== 200) {
             //@codeCoverageIgnoreStart
             throw new RuntimeException("No new nonce - fetched {$this->newNonce} got " . $result['header']);
             //@codeCoverageIgnoreEnd


### PR DESCRIPTION
See https://community.letsencrypt.org/t/acme-v2-change-to-http-status-code-for-head-new-nonce/82000 & https://github.com/yourivw/LEClient/pull/60